### PR TITLE
Update demo smartwizard2-validation.php to hide stale error msgs

### DIFF
--- a/more_examples/smartwizard2-validation.php
+++ b/more_examples/smartwizard2-validation.php
@@ -61,6 +61,7 @@
           $('#wizard').smartWizard('showMessage','Please correct the errors in step'+step+ ' and click next.');
           $('#wizard').smartWizard('setError',{stepnum:step,iserror:true});         
         }else{
+          $('#wizard').smartWizard('hideMessage');
           $('#wizard').smartWizard('setError',{stepnum:step,iserror:false});
         }
       }
@@ -72,6 +73,7 @@
           $('#wizard').smartWizard('showMessage','Please correct the errors in step'+step+ ' and click next.');
           $('#wizard').smartWizard('setError',{stepnum:step,iserror:true});         
         }else{
+          $('#wizard').smartWizard('hideMessage');
           $('#wizard').smartWizard('setError',{stepnum:step,iserror:false});
         }
       }


### PR DESCRIPTION
Once 'showMessage' displays an error message, the message persists after the error has been cleared, even into the next step. This change will call 'hideMessage' to  hide the error message once the error has been cleared.
