### PR TITLE
Slide left animation should work

### DIFF
--- a/js/jquery.smartWizard.js
+++ b/js/jquery.smartWizard.js
@@ -203,7 +203,7 @@ function SmartWizard(target, options) {
             var nextElmLeft = null;
             var curElementLeft = 0;
             if(stepIdx > prevCurStepIdx){
-                nextElmLeft1 = $this.contentWidth + 10;
+                nextElmLeft1 = $this.elmStepContainer.width() + 10;
                 nextElmLeft2 = 0;
                 curElementLeft = 0 - _step($this, curStep).outerWidth();
             } else {
@@ -262,7 +262,7 @@ function SmartWizard(target, options) {
         if (! $this.options.cycleSteps){
             if (0 >= $this.curStepIdx) {
                 $($this.buttons.previous).addClass("buttonDisabled");
-				if ($this.options.hideButtonsOnDisabled) {
+        if ($this.options.hideButtonsOnDisabled) {
                     $($this.buttons.previous).hide();
                 }
             }else{
@@ -435,7 +435,7 @@ $.fn.smartWizard.defaults = {
     contentCache:true, // cache step contents, if false content is fetched always from ajax url
     cycleSteps: false, // cycle step navigation
     enableFinishButton: false, // make finish button enabled always
-	hideButtonsOnDisabled: false, // when the previous/next/finish buttons are disabled, hide them instead?
+  hideButtonsOnDisabled: false, // when the previous/next/finish buttons are disabled, hide them instead?
     errorSteps:[],    // Array Steps with errors
     labelNext:'Next',
     labelPrevious:'Previous',


### PR DESCRIPTION
Fixes the `slideleft` animation. It thinks the element width is 0 because the element is hidden when the width is stored in the $this.contentWidth variable. I changed it so it grabs it dynamically. Happy for any other tweak though.
