### PR TITLE
- Made the width and height of the smart wizard responsive. It now scale...

### DIFF
--- a/styles/smart_wizard.css
+++ b/styles/smart_wizard.css
@@ -14,7 +14,7 @@
   border: 0 solid #CCC;
   overflow:visible;
   float:left;
-  width:980px;
+  width: 100%;
 }
 .swMain .stepContainer {
   display:block;
@@ -22,8 +22,6 @@
   margin: 0;
   padding:0;    
   border: 0 solid #CCC;
-  overflow-x: hidden;
-  overflow-y: scroll;
   clear:both;
   height:300px;
 }
@@ -38,21 +36,26 @@
   font: normal 12px Verdana, Arial, Helvetica, sans-serif; 
   color:#5A5655;   
   background-color:#F8F8F8;  
-  height:300px;
+  height: auto;
   text-align:left;
   overflow:visible;    
   z-index:88; 
   -webkit-border-radius: 5px;
-  -moz-border-radius  : 5px;
-  width:968px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
+  width: 100%;
   clear:both;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 .swMain div.actionBar {
   display:block;
   position: relative; 
   clear:both;
-  margin:             3px 0 0 0;   
+  margin:             3px 0 10px 0;   
   border:             1px solid #CCC;
   padding:            0;    
   color:              #5A5655;   
@@ -63,7 +66,8 @@
   z-index:88; 
 
   -webkit-border-radius: 5px;
-  -moz-border-radius  : 5px;
+  -moz-border-radius: 5px;
+  border-radius: 5px;
   left:0;
 }
 
@@ -80,7 +84,8 @@
   text-align:left; 
   z-index:88;
   -webkit-border-radius: 5px;
-  -moz-border-radius  : 5px;    
+  -moz-border-radius: 5px;
+  border-radius: 5px;    
 }
 .swMain ul.anchor {
   position: relative;
@@ -97,9 +102,13 @@
   position: relative; 
   display:block;
   margin: 0;
-  padding: 0 3px;
+  padding-right: 6px;
   border: 0 solid #E0E0E0;
   float: left;
+}
+.swMain ul.anchor li:last-child
+{
+  padding-right: 0;
 }
 /* Anchor Element Style */
 .swMain ul.anchor li a {
@@ -109,11 +118,12 @@
   margin: 5px 0 0 0;
   padding:3px;
   height:60px;
-  width:230px;
+  width: auto;
   text-decoration: none;
   outline-style:none;
-  -moz-border-radius  : 5px;
+  -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
+  border-radius: 5px;
   z-index:99;
 }
 .swMain ul.anchor li a .stepNumber{
@@ -195,8 +205,9 @@
   outline-style:none;
   background-color:   #5A5655;
   border: 1px solid #5A5655;
-  -moz-border-radius  : 5px; 
-  -webkit-border-radius: 5px;    
+  -moz-border-radius: 5px; 
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
 }
 .swMain .buttonDisabled {
   color:#F8F8F8  !important;
@@ -217,8 +228,9 @@
   outline-style:none;
   background-color:   #5A5655;
   border: 1px solid #5A5655;
-  -moz-border-radius  : 5px; 
-  -webkit-border-radius: 5px;    
+  -moz-border-radius: 5px; 
+  -webkit-border-radius: 5px;
+  border-radius: 5px;  
 }
 .swMain .buttonFinish {
   display:block;
@@ -233,8 +245,9 @@
   outline-style:none;
   background-color:   #5A5655;
   border: 1px solid #5A5655;
-  -moz-border-radius  : 5px; 
-  -webkit-border-radius: 5px;    
+  -moz-border-radius: 5px; 
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
 }
 
 /* Form Styles */
@@ -260,8 +273,9 @@
   font: bold 13px Verdana, Arial, Helvetica, sans-serif; 
   color:#5A5655;       
   background: #FFF url(../images/loader.gif) no-repeat 5px;  
-  -moz-border-radius  : 5px;
+  -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
+  border-radius: 5px;
   z-index:998;
 }
 .swMain .msgBox {
@@ -274,8 +288,9 @@
   background-color: #FFFFDD;  
   font: normal 12px Verdana, Arial, Helvetica, sans-serif; 
   color:#5A5655;         
-  -moz-border-radius  : 5px;
+  -moz-border-radius: 5px;
   -webkit-border-radius: 5px;
+  border-radius: 5px;
   z-index:999;
   min-width:200px;  
 }
@@ -286,6 +301,8 @@
 }
 .swMain .msgBox .close {
   border: 1px solid #CCC;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
   border-radius: 3px;
   color: #CCC;
   display: block;


### PR DESCRIPTION
- Made the width and height of the smart wizard responsive. It now scales depending on window size. You can optionally override this with static values using your own CSS for container height/width.
- Using border-box to accomodate responsive 100% width. Otherwise, padding overflows outside container.
- Removed unecessary overflow-x and overflow-y css since width and height autoscale.
- Added border-radius property where it was missing. Necessary for browsers that don't use moz-border-radius and webkit-border-radius.
