### PR TITLE
Removed the line that adds fixed height

### DIFF
--- a/js/jquery.smartWizard.js
+++ b/js/jquery.smartWizard.js
@@ -209,7 +209,7 @@ function SmartWizard(target, options) {
                 }
             }
         }
-        $this.elmStepContainer.height(_step($this, selStep).outerHeight());
+        // $this.elmStepContainer.height(_step($this, selStep).outerHeight()); 
         var prevCurStepIdx = $this.curStepIdx;
         $this.curStepIdx =  stepIdx;
         if ($this.options.transitionEffect == 'slide'){


### PR DESCRIPTION
I had issues with the div not adjusting/adapting/rendering the height correctly specially when one of the slide has a `.collapse` element. Removing the line fixed it for me.