### PR TITLE
Changes to make 'more_examples' work out of the box

### DIFF
--- a/more_examples/services/service.php
+++ b/more_examples/services/service.php
@@ -1,4 +1,5 @@
-<?
+<?php 
+
   $action = $_REQUEST["action"];
   switch($action){
       case "1":
@@ -10,7 +11,7 @@
 
  function getContent(){
    //sleep(1); 
-   $step_number = $_REQUEST["step_number"]; 
+   $step_number = $_POST["step_number"]; 
    $html = '<h2 class="StepTitle">Step '.$step_number.' Content</h2>';
    if($step_number == 1){
       $html .='<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, 

--- a/more_examples/smartwizard2-ajax.htm
+++ b/more_examples/smartwizard2-ajax.htm
@@ -2,11 +2,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Smart Wizard 2 - Ajax Contents Example - a javascript jQuery wizard control plugin</title>
-<link href="styles/demo_style.css" rel="stylesheet" type="text/css">
+<link href="../styles/demo_style.css" rel="stylesheet" type="text/css">
 
-<link href="styles/smart_wizard.css" rel="stylesheet" type="text/css">
-<script type="text/javascript" src="js/jquery-1.4.2.min.js"></script>
-<script type="text/javascript" src="js/jquery.smartWizard.js"></script>
+<link href="../styles/smart_wizard.css" rel="stylesheet" type="text/css">
+<script type="text/javascript" src="../js/jquery-2.0.0.min.js"></script>
+<script type="text/javascript" src="../js/jquery.smartWizard.js"></script>
 
 <script type="text/javascript">
     $(document).ready(function(){

--- a/more_examples/smartwizard2-validation.php
+++ b/more_examples/smartwizard2-validation.php
@@ -2,11 +2,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Smart Wizard 2 - Step Validation Example - a javascript jQuery wizard control plugin</title>
-<link href="styles/demo_style.css" rel="stylesheet" type="text/css">
+<link href="../styles/demo_style.css" rel="stylesheet" type="text/css">
 
-<link href="styles/smart_wizard.css" rel="stylesheet" type="text/css">
-<script type="text/javascript" src="js/jquery-1.4.2.min.js"></script>
-<script type="text/javascript" src="js/jquery.smartWizard-2.0.min.js"></script>
+<link href="../styles/smart_wizard.css" rel="stylesheet" type="text/css">
+<script type="text/javascript" src="../js/jquery-2.0.0.min.js"></script>
+<script type="text/javascript" src="../js/jquery.smartWizard-2.0.min.js"></script>
 
 <script type="text/javascript">
    


### PR DESCRIPTION
1. Issue with relative paths of the included js and css files in the ajax example.
2. service.php wasn't working on some servers, fixed by explicitly writing <?php instead of <?