### PR TITLE
added buttonOrder, removed reverseButtonOrder and includeFinishButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ $('#wizard').smartWizard({
   // Events
     onLeaveStep: null, // triggers when leaving a step
     onShowStep: null,  // triggers when showing a step
-    onFinish: null,  // triggers when Finish button is clicked
-    includeFinishButton : true,   // Add the finish button
-    reverseButtonsOrder: false //shows buttons ordered as: prev, next and finish    
+    onFinish: null,  // triggers when Finish button is clicked 
+    buttonOrder: ['finish', 'next', 'prev']  // button order, to hide a button remove it from the list
 }); 
 ```
 
@@ -425,24 +424,12 @@ example:
         <td>POST</td>
     </tr>
      <tr>
-        <td><strong>includeFinishButton</strong></td>
-        <td>If true, adds a finish button</td>
+        <td><strong>buttonOrder</strong></td>
+        <td>Defines the display order of the buttons. To hide a button simply remove it from the list.</td>
         <td>
-            true = show
-            <br />
-            false= don't show
+             String[]
         </td>
-        <td>true</td>
-     </tr>
-     <tr>
-        <td><strong>reverseButtonsOrder</strong></td>
-        <td>If true, shows buttons ordered as: prev, next, finished</td>
-        <td>
-            true = prev, next, finished
-            <br />
-            false= finished, next, prev
-        </td>
-        <td>false</td>        
+        <td>['finish', 'next', 'prev']</td>        
      </tr>
 
 </table>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $('#wizard').smartWizard({
   // Events
     onLeaveStep: null, // triggers when leaving a step
     onShowStep: null,  // triggers when showing a step
-    onFinish: null,  // triggers when Finish button is clicked 
+    onFinish: null,  // triggers when Finish button is clicked  
     buttonOrder: ['finish', 'next', 'prev']  // button order, to hide a button remove it from the list
 }); 
 ```
@@ -423,6 +423,26 @@ example:
         <td>String</td>
         <td>POST</td>
     </tr>
+     <tr>
+        <td><strong>includeFinishButton</strong></td>
+        <td>**[DEPRECATED: Will be removed in the next release]** If true, adds a finish button</td>
+        <td>
+            true = show
+            <br />
+            false= don't show
+        </td>
+        <td>true</td>
+     </tr>
+     <tr>
+        <td><strong>reverseButtonsOrder</strong></td>
+        <td>**[DEPRECATED: Will be removed in the next release]** If true, shows buttons ordered as: prev, next, finished</td>
+        <td>
+            true = prev, next, finished
+            <br />
+            false= finished, next, prev
+        </td>
+        <td>false</td>        
+     </tr>
      <tr>
         <td><strong>buttonOrder</strong></td>
         <td>Defines the display order of the buttons. To hide a button simply remove it from the list.</td>

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ example:
     </tr>
      <tr>
         <td><strong>includeFinishButton</strong></td>
-        <td>**[DEPRECATED: Will be removed in the next release]** If true, adds a finish button</td>
+        <td><strong>[DEPRECATED: This option will be removed in the next release]</strong> If true, adds a finish button</td>
         <td>
             true = show
             <br />
@@ -435,7 +435,7 @@ example:
      </tr>
      <tr>
         <td><strong>reverseButtonsOrder</strong></td>
-        <td>**[DEPRECATED: Will be removed in the next release]** If true, shows buttons ordered as: prev, next, finished</td>
+        <td><strong>[DEPRECATED: This option will be removed in the next release]</strong> If true, shows buttons ordered as: prev, next, finished</td>
         <td>
             true = prev, next, finished
             <br />

--- a/js/jquery.smartWizard.js
+++ b/js/jquery.smartWizard.js
@@ -73,20 +73,26 @@ function SmartWizard(target, options) {
         $this.elmStepContainer.append(allDivs);
         elmActionBar.append($this.loader);
         $this.target.append($this.elmStepContainer);
-        
-        if($this.options.reverseButtonsOrder){
-            elmActionBar.append($this.buttons.previous)
-                        .append($this.buttons.next);
-            if ($this.options.includeFinishButton){
-                elmActionBar.append($this.buttons.finish)
+
+        for( var btnIndex in $this.options.buttonOrder)
+        {
+            if(!$this.options.buttonOrder.hasOwnProperty(btnIndex))
+            {
+                continue;
             }
-        }
-        else {
-            if ($this.options.includeFinishButton){
-                elmActionBar.append($this.buttons.finish)
+
+            switch($this.options.buttonOrder[btnIndex])
+            {
+                case 'finish':
+                    elmActionBar.append($this.buttons.finish);
+                    break;
+                case 'next':
+                    elmActionBar.append($this.buttons.next);
+                    break;
+                case 'prev':
+                    elmActionBar.append($this.buttons.previous);
+                    break;
             }
-            elmActionBar.append($this.buttons.next)
-                        .append($this.buttons.previous);
         }
         
         $this.target.append(elmActionBar);
@@ -493,7 +499,8 @@ function SmartWizard(target, options) {
         onShowStep: null,  // triggers when showing a step
         onFinish: null,  // triggers when Finish button is clicked
         includeFinishButton : true,   // Add the finish button
-        reverseButtonsOrder: false //shows buttons ordered as: prev, next and finish       
+        reverseButtonsOrder: false, //shows buttons ordered as: prev, next and finish
+        buttonOrder: ['finish', 'next', 'prev']  // button order, to hide a button remove it from the list
 };
 
 })(jQuery);

--- a/js/jquery.smartWizard.js
+++ b/js/jquery.smartWizard.js
@@ -457,7 +457,31 @@ function SmartWizard(target, options) {
         var allObjs = this.each(function() {
             var wiz = $(this).data('smartWizard');
             if (typeof method == 'object' || ! method || ! wiz) {
+
+                // show deprecated message for includeFinishButton  and reverseButtonsOrder options
+                if(method.hasOwnProperty('includeFinishButton') || method.hasOwnProperty('reverseButtonsOrder'))
+                {
+                    console.log("[WARNING] Parameter 'includeFinishButton' and 'reverseButtonsOrder' are " +
+                        "deprecated an will be removed in the next release. Use option 'buttonOrder' instead.");
+                }
+
                 var options = $.extend({}, $.fn.smartWizard.defaults, method || {});
+
+                // handle deprecated reverseButtonsOrder option
+                if(options.reverseButtonsOrder === true)
+                {
+                    options.buttonOrder.reverse()
+                }
+
+                // handle deprecated includeFinishButton option
+                if(options.includeFinishButton === false)
+                {
+                    var index = options.buttonOrder.indexOf('finish');
+                    if (index > -1) {
+                        options.buttonOrder.splice(index, 1);
+                    }
+                }
+
                 if (! wiz) {
                     wiz = new SmartWizard($(this), options);
                     $(this).data('smartWizard', wiz);


### PR DESCRIPTION
Replaced reverseButtonOrder and includeFinishButton with the new option
buttonOrder. ButtonOrder is a String array which can take up to 3 elements.
These elements are 'finish', 'next' and 'prev'. By changing the order of
the elements in the buttonOrder the Order of the buttons will change.
Elements will not be displayed if removed from the list.
By replacing reverseButtonOrder and includeFinishButton with buttonOrder,
a better customizing and LTR integration will be possible